### PR TITLE
Update install instruction for yarn

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 ```shell
 npm install scroll-lock
 # or
-yarn install scroll-lock
+yarn add scroll-lock
 ```
 ```js
 //es6 import


### PR DESCRIPTION
```
yarn install v1.13.0
error `install` has been replaced with `add` to add new dependencies. Run "yarn add scroll-lock" instead.
```